### PR TITLE
Replace dream-sports-labs with ds-horizon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ShardManagerConfig**: Extended with `routerType` field supporting MODULO (default) and CONSISTENT options
 
 ### Fixed
-- **Test Infrastructure** ([#12](https://github.com/dream-sports-labs/shard-wizard/pull/12)): Comprehensive test fixes and refactoring
+- **Test Infrastructure** ([#12](https://github.com/ds-horizon/shard-wizard/pull/12)): Comprehensive test fixes and refactoring
   - Fixed DynamoDB shard manager configuration and test cases
   - Resolved PostgreSQL configuration issues in test environments
   - Corrected syntax errors and removed unused test files

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <description>Vert.x library for scalable shard management and routing of entities across multiple
     shards
   </description>
-  <url>https://github.com/dream-sports-labs/shard-wizard</url>
+  <url>https://github.com/ds-horizon/shard-wizard</url>
 
   <licenses>
     <license>
@@ -23,9 +23,9 @@
   </licenses>
 
   <scm>
-    <url>https://github.com/dream-sports-labs/shard-wizard</url>
-    <connection>scm:git:git://github.com/dream-sports-labs/shard-wizard.git</connection>
-    <developerConnection>scm:git:ssh://github.com/dream-sports-labs/shard-wizard.git
+    <url>https://github.com/ds-horizon/shard-wizard</url>
+    <connection>scm:git:git://github.com/ds-horizon/shard-wizard.git</connection>
+    <developerConnection>scm:git:ssh://github.com/ds-horizon/shard-wizard.git
     </developerConnection>
   </scm>
 


### PR DESCRIPTION
This PR replaces all occurrences of "dream-sports-labs" with "ds-horizon" in the repository.

## Changes Made
- Updated CHANGELOG.md references
- Updated pom.xml references

## Files Modified
- CHANGELOG.md
- pom.xml